### PR TITLE
updated for graph API 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,22 @@ By default the requested scope is "public_profile". Scope can be configured eith
 ```elixir
 config :ueberauth, Ueberauth,
   providers: [
-    facebook: {Ueberauth.Strategy.Facebook, [default_scope: "emails,public_profile,user_friends"]}
+    facebook: {Ueberauth.Strategy.Facebook, [default_scope: "email,public_profile,user_friends"]}
   ]
 ```
+
+Starting with Graph API version 2.4, Facebook has limited the default fields returned when fetching the user profile.
+Fields can be explicitly requested using the `profile_fields` option:
+
+```elixir
+config :ueberauth, Ueberauth,
+  providers: [
+    facebook: {Ueberauth.Strategy.Facebook, [profile_fields: "name,email,first_name,last_name"]}
+  ]
+```
+
+See [Graph API Reference > User](https://developers.facebook.com/docs/graph-api/reference/user) for full list of fields.
+
 
 ## License
 

--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -3,7 +3,7 @@ defmodule Ueberauth.Strategy.Facebook do
   Facebook Strategy for Überauth.
   """
 
-  use Ueberauth.Strategy, uid_field: :id, default_scope: "email"
+  use Ueberauth.Strategy, uid_field: :id, default_scope: "email", profile_fields: ""
 
   alias Ueberauth.Auth.Info
   alias Ueberauth.Auth.Credentials
@@ -88,7 +88,7 @@ defmodule Ueberauth.Strategy.Facebook do
       image: fetch_image(user["id"]),
       last_name: user["last_name"],
       name: user["name"],
-      nickname: user["username"],
+      nickname: nil,
       urls: %{
         facebook: user["link"],
         website: user["website"]
@@ -112,7 +112,7 @@ defmodule Ueberauth.Strategy.Facebook do
 
   defp fetch_user(conn, token) do
     conn = put_private(conn, :facebook_token, token)
-    case OAuth2.AccessToken.get(token, "/me") do
+    case OAuth2.AccessToken.get(token, "/me?fields=#{option(conn, :profile_fields)}") do
       { :ok, %OAuth2.Response{status_code: 401, body: _body}} ->
         set_errors!(conn, [error("token", "unauthorized")])
       { :ok, %OAuth2.Response{status_code: status_code, body: user} } when status_code in 200..399 ->

--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -88,7 +88,6 @@ defmodule Ueberauth.Strategy.Facebook do
       image: fetch_image(user["id"]),
       last_name: user["last_name"],
       name: user["name"],
-      nickname: nil,
       urls: %{
         facebook: user["link"],
         website: user["website"]


### PR DESCRIPTION
Made a small update which allows to specifically request profile fields. I found that facebook was only returning the name and ID. The change to their API is detailed here: 

> Fewer default fields for faster performance: To help improve performance on mobile network connections, we've reduced the number of fields that the API returns by default. You should now use the ?fields=field1,field2 syntax to declare all the fields you want the API to return.

https://developers.facebook.com/blog/post/2015/07/08/graph-api-v2.4/

I'd like to add some tests, but I'm not quite sure where to get started. Open to suggestiions. 
