### PR TITLE
initial request with auth_type=rerequest

### DIFF
--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -14,7 +14,7 @@ defmodule Ueberauth.Strategy.Facebook do
   """
   def handle_request!(conn) do
     scopes = conn.params["scope"] || option(conn, :default_scope)
-    opts = [ scope: scopes ]
+    opts = [ scope: scopes, auth_type: "rerequest" ]
     if conn.params["state"], do: opts = Keyword.put(opts, :state, conn.params["state"])
     opts = Keyword.put(opts, :redirect_uri, callback_url(conn))
     IO.inspect opts


### PR DESCRIPTION
I added `auth_type:rerequest` field at the initial request(it works well even really the initial request).

Use case:
You need the email from a user. You redirect the user to Facebook, and in a confirmation dialog, in "Edit the info you provide", he un-checks Email address. You can know that with a pattern matching like following:

``` elixir
def callback(%{ assigns: %{ueberauth_auth: auth}, assigns: %{ueberauth_auth: %{ info: %{ email: nil }}}} = conn, params do
```

But, the user has already accept the application, you cannot re-request the missing data, except requested with `auth_type:rerequest` anymore.
