### PR TITLE
Remove unnecessary auth_type default

### DIFF
--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -3,8 +3,7 @@ defmodule Ueberauth.Strategy.Facebook do
   Facebook Strategy for Überauth.
   """
 
-  use Ueberauth.Strategy, auth_type: "",
-                          default_scope: "email",
+  use Ueberauth.Strategy, default_scope: "email",
                           profile_fields: "",
                           uid_field: :id,
                           allowed_request_params: [
@@ -27,7 +26,6 @@ defmodule Ueberauth.Strategy.Facebook do
      |> Enum.map(&to_string/1)
 
     authorize_url = conn.params
-      |> maybe_replace_param(conn, "auth_type", :auth_type)
       |> maybe_replace_param(conn, "scope", :default_scope)
       |> Enum.filter(fn {k,_v} -> Enum.member?(allowed_params, k) end)
       |> Enum.map(fn {k,v} -> {String.to_existing_atom(k), v} end)


### PR DESCRIPTION
RFC @hassox — With your latest change I no longer believe this code is necessary.  This removes the `maybe_replace_param/4` function call and default for `:auth_type`.
