### PR TITLE
revert a line removed by mistake at 1b7044

### DIFF
--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -26,6 +26,7 @@ defmodule Ueberauth.Strategy.Facebook do
      |> Enum.map(&to_string/1)
 
     authorize_url = conn.params
+      |> maybe_replace_param(conn, "auth_type", :auth_type)
       |> maybe_replace_param(conn, "scope", :default_scope)
       |> Enum.filter(fn {k,_v} -> Enum.member?(allowed_params, k) end)
       |> Enum.map(fn {k,v} -> {String.to_existing_atom(k), v} end)


### PR DESCRIPTION
You've removed a line which replaces auth_type parameter at commit 1b7044,
