### PR TITLE
make state parameter replacable by params

### DIFF
--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -29,6 +29,7 @@ defmodule Ueberauth.Strategy.Facebook do
     authorize_url = conn.params
       |> maybe_replace_param(conn, "auth_type", :auth_type)
       |> maybe_replace_param(conn, "scope", :default_scope)
+      |> maybe_replace_param(conn, "state", :state)
       |> Enum.filter(fn {k,_v} -> Enum.member?(allowed_params, k) end)
       |> Enum.map(fn {k,v} -> {String.to_existing_atom(k), v} end)
       |> Keyword.put(:redirect_uri, callback_url(conn))


### PR DESCRIPTION
This allows to have a link like "/auth/facebook?state=foo". In the callback phase the state parameter will be returned by Facebook.
