### PR TITLE
Add display type to facebook oauth string to support popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
+Additionally you can now specify the `display` param to pass to Facebook:
+
+```elixir
+config :ueberauth, Ueberauth,
+  providers: [
+    facebook: {Ueberauth.Strategy.Facebook, [
+      default_scope: "email,public_profile,user_friends",
+      display: "popup"
+    ]}
+  ]
+```
+
+`display` can be the following values: `page` (default), `async`, `iframe`, `popup`, `touch`, `wap`
+
 Starting with Graph API version 2.4, Facebook has limited the default fields returned when fetching the user profile.
 Fields can be explicitly requested using the `profile_fields` option:
 

--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -11,7 +11,7 @@ defmodule Ueberauth.Strategy.Facebook do
                             :scope,
                             :locale,
                             :state,
-                            :display  # page (default), async, iframe, popup, touch, wap
+                            :display
                           ]
 
 

--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -10,7 +10,8 @@ defmodule Ueberauth.Strategy.Facebook do
                             :auth_type,
                             :scope,
                             :locale,
-                            :state
+                            :state,
+                            :display  # page (default), async, iframe, popup, touch, wap
                           ]
 
 
@@ -30,6 +31,7 @@ defmodule Ueberauth.Strategy.Facebook do
       |> maybe_replace_param(conn, "auth_type", :auth_type)
       |> maybe_replace_param(conn, "scope", :default_scope)
       |> maybe_replace_param(conn, "state", :state)
+      |> maybe_replace_param(conn, "display", :display)
       |> Enum.filter(fn {k,_v} -> Enum.member?(allowed_params, k) end)
       |> Enum.map(fn {k,v} -> {String.to_existing_atom(k), v} end)
       |> Keyword.put(:redirect_uri, callback_url(conn))


### PR DESCRIPTION
It looks better in a part of my app if I use the display=popup parameter for the request url... 

Does it need a test?
