### PR TITLE
Fix login failure on Phoenix apps generated after oauth2 0.7.0 was released

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule UeberauthFacebook.Mixfile do
 
   defp deps do
     [{:ueberauth, "~> 0.2"},
-     {:oauth2, "~> 0.5"},
+     {:oauth2, "~> 0.5.0"},
      {:ex_doc, "~> 0.1", only: :dev},
      {:earmark, ">= 0.0.0", only: :dev},
      {:dogma, ">= 0.0.0", only: [:dev, :test]}]


### PR DESCRIPTION
This fixes an issue introduced in oauth2 0.7.0. ueberauth_facebook currently requires oauth2 using the '~> 0.5' version string which causes new Phoenix apps to pull oauth2 0.7.0. This results in login failures due to API changes between oauth2 0.5.0 and oauth2 0.7.0
