### PR TITLE
Provide `appsecret_proof` parameter

### DIFF
--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -151,8 +151,8 @@ defmodule Ueberauth.Strategy.Facebook do
   end
 
   defp user_query(conn) do
-    conn
-    |> query_params(:locale)
+    %{}
+    |> Map.merge(query_params(conn, :locale))
     |> Map.merge(query_params(conn, :profile))
     |> URI.encode_query
   end

--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -137,7 +137,7 @@ defmodule Ueberauth.Strategy.Facebook do
 
   defp fetch_user(conn, client) do
     conn = put_private(conn, :facebook_token, client.token)
-    query = user_query(conn)
+    query = user_query(conn, client.token)
     path = "/me?#{query}"
     case OAuth2.Client.get(client, path) do
       {:ok, %OAuth2.Response{status_code: 401, body: _body}} ->
@@ -150,11 +150,24 @@ defmodule Ueberauth.Strategy.Facebook do
     end
   end
 
-  defp user_query(conn) do
-    %{}
+  defp user_query(conn, token) do
+    %{"appsecret_proof" => appsecret_proof(token)}
     |> Map.merge(query_params(conn, :locale))
     |> Map.merge(query_params(conn, :profile))
     |> URI.encode_query
+  end
+
+  defp appsecret_proof(token) do
+    config = Application.get_env(:ueberauth, Ueberauth.Strategy.Facebook.OAuth)
+    client_secret = Keyword.get(config, :client_secret)
+
+    token.access_token
+    |> hmac(:sha256, client_secret)
+    |> Base.encode16(case: :lower)
+  end
+
+  defp hmac(data, type, key) do
+    :crypto.hmac(type, key, data)
   end
 
   defp query_params(conn, :profile) do


### PR DESCRIPTION
Facebook allows a mean of [securing Graph API requests](https://developers.facebook.com/docs/graph-api/securing-requests) by providing the `appsecret_proof` parameter.

Developers can (per app) toggle a setting to make this required for all requests. That breaks this library:

    ** (exit) an exception was raised:
        ** (CaseClauseError) no case clause matching: {:ok, %OAuth2.Response{body: %{"error" => %{"code" => 100, "fbtrace_id" => "...", "message" => "API calls from the server require an appsecret_proof argument", "type" => "GraphMethodException"}}, headers: [{"WWW-Authenticate", "OAuth \"Facebook Platform\" \"invalid_request\" \"API calls from the server require an appsecret_proof argument\""}, {"Access-Control-Allow-Origin", "*"}, {"Pragma", "no-cache"}, {"Cache-Control", "no-store"}, {"Expires", "Sat, 01 Jan 2000 00:00:00 GMT"}, {"Content-Type", "application/json"}, {"x-fb-trace-id", "..."}, {"x-fb-rev", "..."}, {"Vary", "Accept-Encoding"}, {"X-FB-Debug", "..."}, {"Date", "Sun, 20 Nov 2016 21:54:56 GMT"}, {"Transfer-Encoding", "chunked"}, {"Connection", "keep-alive"}], status_code: 400}}
            (ueberauth_facebook) lib/ueberauth/strategy/facebook.ex:141: Ueberauth.Strategy.Facebook.fetch_user/2
            (ueberauth) lib/ueberauth/strategy.ex:299: Ueberauth.Strategy.run_callback/2
            ...

There is no problem providing this parameter consistently so this pull request does that.