### PR TITLE
Removes runtime deprecation warnings in Elixir 1.4

### DIFF
--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -181,11 +181,11 @@ defmodule Ueberauth.Strategy.Facebook do
   end
 
   defp option(conn, key) do
-    default = Dict.get(default_options, key)
+    default = Keyword.get(default_options(), key)
 
     conn
     |> options
-    |> Dict.get(key, default)
+    |> Keyword.get(key, default)
   end
   defp option(nil, conn, key), do: option(conn, key)
   defp option(value, _conn, _key), do: value

--- a/mix.exs
+++ b/mix.exs
@@ -8,15 +8,15 @@ defmodule UeberauthFacebook.Mixfile do
     [app: :ueberauth_facebook,
      version: @version,
      name: "Ueberauth Facebook Strategy",
-     package: package,
+     package: package(),
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      source_url: @url,
      homepage_url: @url,
-     description: description,
-     deps: deps,
-     docs: docs]
+     description: description(),
+     deps: deps(),
+     docs: docs()]
   end
 
   def application do


### PR DESCRIPTION
This commit resolves the following deprecation warnings having to do with function invocation vs variables in Elixir 1.4, as well as using the `Keyword` module, rather than `Dict`.