### PR TITLE
From 10 July 2017 the new facebook api requires to pass along profile_fields.

### DIFF
--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -3,8 +3,8 @@ defmodule Ueberauth.Strategy.Facebook do
   Facebook Strategy for Überauth.
   """
 
-  use Ueberauth.Strategy, default_scope: "email",
-                          profile_fields: "",
+  use Ueberauth.Strategy, default_scope: "email,public_profile",
+                          profile_fields: "id,email,gender,link,locale,name,timezone,updated_time,verified",
                           uid_field: :id,
                           allowed_request_params: [
                             :auth_type,


### PR DESCRIPTION
If the profile_fields is empty you will not get the email back, even if that is defined in the scope. An other change is that you also need to pass along public_profile along with email in the scope for this to work.

One of my older applications is running api v2.3 which is working with the current version of ueberauth_facebook but this support will be pulled on 10 July 2017.

Also any newly created facebook app is not returning the email without these changes.