### PR TITLE
Allow option to specify scheme for usar avatar url. Defaults to http

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ otp_release:
   - 18.3
 matrix:
   exclude:
+    - elixir: 1.6
+      otp_release: 18.3
     - elixir: 1.3
-      otp_release: 20.0
+      otp_release: 20.2
 script:
   - mix test
   - mix credo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: elixir
 elixir:
+  - 1.6
+  - 1.5
   - 1.4
   - 1.3
 otp_release:
-  - 20.0
+  - 20.2
   - 19.3
   - 18.3
 matrix:

--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -3,9 +3,6 @@ defmodule Ueberauth.Strategy.Facebook do
   Facebook Strategy for Überauth.
   """
 
-
-
-
   use Ueberauth.Strategy, default_scope: "email,public_profile",
                           profile_fields: "id,email,gender,link,locale,name,timezone,updated_time,verified",
                           uid_field: :id,
@@ -15,8 +12,7 @@ defmodule Ueberauth.Strategy.Facebook do
                             :locale,
                             :state,
                             :display
-                          ],
-                          image_scheme: "http"
+                          ]
 
 
   alias Ueberauth.Auth.Info
@@ -107,13 +103,12 @@ defmodule Ueberauth.Strategy.Facebook do
   """
   def info(conn) do
     user = conn.private.facebook_user
-    scheme = option(conn, :image_scheme)
 
     %Info{
       description: user["bio"],
       email: user["email"],
       first_name: user["first_name"],
-      image: fetch_image(scheme,user["id"]),
+      image: fetch_image(user["id"]),
       last_name: user["last_name"],
       name: user["name"],
       urls: %{
@@ -136,8 +131,8 @@ defmodule Ueberauth.Strategy.Facebook do
     }
   end
 
-  defp fetch_image(scheme,uid) do
-    "#{scheme}://graph.facebook.com/#{uid}/picture?type=square"
+  defp fetch_image(uid) do
+    "http://graph.facebook.com/#{uid}/picture?type=square"
   end
 
   defp fetch_user(conn, client) do

--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -132,7 +132,7 @@ defmodule Ueberauth.Strategy.Facebook do
   end
 
   defp fetch_image(uid) do
-    "http://graph.facebook.com/#{uid}/picture?type=square"
+    "https://graph.facebook.com/#{uid}/picture?type=square"
   end
 
   defp fetch_user(conn, client) do

--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -3,6 +3,9 @@ defmodule Ueberauth.Strategy.Facebook do
   Facebook Strategy for Überauth.
   """
 
+
+
+
   use Ueberauth.Strategy, default_scope: "email,public_profile",
                           profile_fields: "id,email,gender,link,locale,name,timezone,updated_time,verified",
                           uid_field: :id,
@@ -12,7 +15,8 @@ defmodule Ueberauth.Strategy.Facebook do
                             :locale,
                             :state,
                             :display
-                          ]
+                          ],
+                          image_scheme: "http"
 
 
   alias Ueberauth.Auth.Info
@@ -103,12 +107,13 @@ defmodule Ueberauth.Strategy.Facebook do
   """
   def info(conn) do
     user = conn.private.facebook_user
+    scheme = option(conn, :image_scheme)
 
     %Info{
       description: user["bio"],
       email: user["email"],
       first_name: user["first_name"],
-      image: fetch_image(user["id"]),
+      image: fetch_image(scheme,user["id"]),
       last_name: user["last_name"],
       name: user["name"],
       urls: %{
@@ -131,8 +136,8 @@ defmodule Ueberauth.Strategy.Facebook do
     }
   end
 
-  defp fetch_image(uid) do
-    "http://graph.facebook.com/#{uid}/picture?type=square"
+  defp fetch_image(scheme,uid) do
+    "#{scheme}://graph.facebook.com/#{uid}/picture?type=square"
   end
 
   defp fetch_user(conn, client) do

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Ueberauth.Facebook.Mixfile do
     [{:ueberauth, "~> 0.4"},
      {:oauth2, "~> 0.9"},
 
-     {:credo, "~> 0.8", only: [:dev, :test]},
+     {:credo, "~> 0.8.10", only: [:dev, :test]},
      {:ex_doc, "~> 0.16", only: :dev},
      {:earmark, ">= 0.0.0", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,15 +1,17 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [:rebar3], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.4", "4e50acac058cf6292d6066e5b0d03da5e1483702e1ccde39abba385c9f03ead4", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.8.6", "21a725db3569b3fb11a6af17d5c5f654052ce9624219f1317e8639183de4a423", [:rebar3], [{:certifi, "1.2.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.0.2", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.0.2", "ac203208ada855d95dc591a764b6e87259cb0e2a364218f215ad662daa8cd6b4", [:rebar3], [{:unicode_util_compat, "0.2.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
-  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], [], "hexpm"},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
-  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [], [], "hexpm"},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "oauth2": {:hex, :oauth2, "0.9.1", "cac86d87f35ec835bfe4c791263bdb88c0d8bf1617d64f555ede4e9d913e35ef", [:mix], [{:hackney, "~> 1.7", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "ueberauth": {:hex, :ueberauth, "0.4.0", "bc72d5e5a7bdcbfcf28a756e34630816edabc926303bdce7e171f7ac7ffa4f91", [], [{:plug, "~> 1.2", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], [], "hexpm"}}
+  "ueberauth": {:hex, :ueberauth, "0.4.0", "bc72d5e5a7bdcbfcf28a756e34630816edabc926303bdce7e171f7ac7ffa4f91", [:mix], [{:plug, "~> 1.2", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], [], "hexpm"},
+}


### PR DESCRIPTION
This PR adds the option to specify the scheme for the url of the user's image. It defaults to "http" when none is specified.

I'm not sure how to go about testing this. The repo currently has no tests. Any feedback would be appreciated.

This should fix https://github.com/ueberauth/ueberauth_facebook/issues/39