### PR TITLE
Stop sending empty params to the FB auth dialog

### DIFF
--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -191,7 +191,7 @@ defmodule Ueberauth.Strategy.Facebook do
   defp option(value, _conn, _key), do: value
 
   defp maybe_replace_param(params, conn, name, config_key) do
-    if params[name] do
+    if params[name] || is_nil(option(params[name], conn, config_key)) do
       params
     else
       Map.put(


### PR DESCRIPTION
Fixes #45