### PR TITLE
Allow oauth2 library version 2.x

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Ueberauth.Facebook.Mixfile do
 
   defp deps do
     [{:ueberauth, "~> 0.6.0"},
-     {:oauth2, "~> 1.0.0"},
+     {:oauth2, "~> 1.0 or ~> 2.0"},
 
      {:credo, "~> 0.8.10", only: [:dev, :test]},
      {:ex_doc, "~> 0.19", only: :dev},


### PR DESCRIPTION
OAuth2 recently changed major versions (without any API breakage), and in line with [other ueberauth providers](https://github.com/ueberauth/ueberauth_google/blob/master/mix.exs#L28) it would be good to support `oauth2 ~> 2.0` here as well.