### PR TITLE
Loosen ueberauth dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Ueberauth.Facebook.Mixfile do
 
   defp deps do
     [
-      {:ueberauth, "~> 0.6.0"},
+      {:ueberauth, "~> 0.6"},
       {:oauth2, "~> 1.0 or ~> 2.0"},
       {:credo, "~> 0.8.10", only: [:dev, :test]},
       {:ex_doc, ">= 0.24.2", only: :dev, runtime: false}


### PR DESCRIPTION
This ensures that we can use 0.7, which has been released