### PR TITLE
Feature/config resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,22 @@
 
 1. Update your provider configuration:
 
+   Use that if you want to read client ID/secret from the environment
+   variables in the compile time:
+
    ```elixir
    config :ueberauth, Ueberauth.Strategy.Facebook.OAuth,
      client_id: System.get_env("FACEBOOK_CLIENT_ID"),
      client_secret: System.get_env("FACEBOOK_CLIENT_SECRET")
+   ```
+
+   Use that if you want to read client ID/secret from the environment
+   variables in the run time:
+
+   ```elixir
+   config :ueberauth, Ueberauth.Strategy.Facebook.OAuth,
+     client_id: {System, :get_env, ["FACEBOOK_CLIENT_ID"]},
+     client_secret: {System, :get_env, ["FACEBOOK_CLIENT_SECRET"]}
    ```
 
 1. Include the Überauth plug in your controller:

--- a/lib/ueberauth/strategy/facebook/oauth.ex
+++ b/lib/ueberauth/strategy/facebook/oauth.ex
@@ -27,12 +27,13 @@ defmodule Ueberauth.Strategy.Facebook.OAuth do
   of Ueberauth.
   """
   def client(opts \\ []) do
-    config = Application.get_env(:ueberauth, Ueberauth.Strategy.Facebook.OAuth, [])
+    config = Application.get_env(:ueberauth, __MODULE__, [])
 
     opts =
       @defaults
       |> Keyword.merge(config)
       |> Keyword.merge(opts)
+      |> resolve_values()
 
     json_library = Ueberauth.json_library()
 
@@ -69,4 +70,13 @@ defmodule Ueberauth.Strategy.Facebook.OAuth do
     |> put_header("Accept", "application/json")
     |> OAuth2.Strategy.AuthCode.get_token(params, headers)
   end
+
+  defp resolve_values(list) do
+    for {key, value} <- list do
+      {key, resolve_value(value)}
+    end
+  end
+
+  defp resolve_value({m, f, a}) when is_atom(m) and is_atom(f), do: apply(m, f, a)
+  defp resolve_value(v), do: v
 end


### PR DESCRIPTION
Amended oAuth strategy to resolve m/f/a tuples which allows to read the provider configuration in run time instead of in compile time.

See [https://github.com/ueberauth/ueberauth_google/pull/60](https://github.com/ueberauth/ueberauth_google/pull/60)